### PR TITLE
Allow arguments to be passed to a model factory

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -26,11 +26,12 @@ class Registry
 
     /**
      * @param $name
+     * @param array $arguments
      * @return mixed|null
      */
-    public static function get($name)
+    public static function get($name, array $arguments = [])
     {
-        return static::has($name) ? static::resolve($name) : null;
+        return static::has($name) ? static::resolve($name, $arguments) : null;
     }
 
     /**
@@ -44,15 +45,19 @@ class Registry
 
     /**
      * @param string $name
+     * @param array $arguments
      * @return mixed
      */
-    public static function resolve(string $name)
+    public static function resolve(string $name, array $arguments = [])
     {
         $item = static::$items[$name];
 
         if ($item instanceof Closure) {
-            $item = $item();
-            static::$items[$name] = $item;
+            $item = $item(...$arguments);
+
+            if (!$arguments) {
+                static::$items[$name] = $item;
+            }
         }
 
         return $item;

--- a/src/Stitch.php
+++ b/src/Stitch.php
@@ -67,15 +67,16 @@ class Stitch
      */
     public static function __callStatic($name, $arguments)
     {
-        return static::resolve($name);
+        return static::resolve($name, $arguments);
     }
 
     /**
      * @param string $name
+     * @param array $arguments
      * @return mixed|null
      */
-    public static function resolve(string $name)
+    public static function resolve(string $name, array $arguments = [])
     {
-        return Registry::get($name);
+        return Registry::get($name, $arguments);
     }
 }


### PR DESCRIPTION
Adding the functionality to allow arguments to be passed to a model factory so that the same model with different parameters (such as the connection) can be created.

NOTE: If arguments are passed to a factory method, the result of the closure resolution is no longer stored in place of the closure.